### PR TITLE
Ajout des pages paramètres et légales V1.12.0

### DIFF
--- a/pangeas-v1/src/App.vue
+++ b/pangeas-v1/src/App.vue
@@ -6,7 +6,7 @@
       <div class="modal-overlay" v-if="showRegistration">
         <div class="modal-content">
           <button class="close-modal" @click="animateClose('registration', $event)">×</button>
-          <Registration v-if="showRegistration" @open-login="showLoginModal"/>
+          <Registration v-if="showRegistration" @open-login="showLoginModal" @close="showRegistration = false"/>
         </div>
       </div>
     </transition>

--- a/pangeas-v1/src/components/Modal/DeleteAccountModal.vue
+++ b/pangeas-v1/src/components/Modal/DeleteAccountModal.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="modal-overlay">
+    <div class="modal-content p-4 rounded shadow">
+      <h3 class="mb-3 text-center" v-if="!confirmation">Vérification d'identité</h3>
+      <h3 class="mb-3 text-center" v-else>Confirmation de suppression</h3>
+
+      <div v-if="successMessage" class="alert alert-success text-center">
+        {{ successMessage }}
+      </div>
+
+      <form v-else @submit.prevent="handleSubmit">
+        <div v-if="!confirmation">
+          <div class="mb-3">
+            <label class="form-label">Adresse mail</label>
+            <input type="email" class="form-control" v-model="email" />
+            <small class="text-danger" v-if="errors.email">{{ errors.email }}</small>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label">Mot de passe</label>
+            <input type="password" class="form-control" v-model="password" />
+            <small class="text-danger" v-if="errors.password">{{ errors.password }}</small>
+          </div>
+
+          <div class="d-flex justify-content-between mt-4">
+            <button type="button" class="btn btn-danger text-white"@click="$emit('close')">Annuler</button>
+            <button type="submit" class="btn next">Suivant</button>
+          </div>
+        </div>
+
+        <div v-else>
+          <p class="text-center fw-bold text-danger mb-4">
+            Voulez-vous vraiment supprimer votre compte ? <br />
+            Cette action est <u>irréversible</u> !<br />
+            Vous n'aurez plus aucun moyen de le récupérer.
+          </p>
+          <div class="d-flex justify-content-between">
+            <button type="button" style="background-color: var(--color-brown);" class="btn text-white" @click="$emit('close')">Annuler</button>
+            <button type="submit" class="btn btn-danger">Supprimer définitivement</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import axios from 'axios';
+
+export default {
+  data() {
+    return {
+      email: '',
+      password: '',
+      confirmation: false,
+      errors: {},
+      successMessage: ''
+    };
+  },
+  computed: {
+    ...mapState({
+      user: state => state.user
+    })
+  },
+  mounted() {
+    if (this.user?.email) {
+      this.email = this.user.email;
+    }
+  },
+  methods: {
+    async handleSubmit() {
+      this.errors = {};
+      try {
+        if (!this.confirmation) {
+          this.confirmation = true;
+          return;
+        }
+
+        const response = await axios.delete('/api/settings/delete', {
+          data: {
+            email: this.email,
+            password: this.password
+          },
+          withCredentials: true
+        });
+
+        if (response.data.success) {
+          this.successMessage = response.data.message;
+          this.$store.commit('logout');
+
+          setTimeout(() => {
+            this.$router.push({ name: 'Home' });
+          }, 2000);
+        }
+      } catch (error) {
+        if (error.response?.data?.errors) {
+          for (const err of error.response.data.errors) {
+            this.errors[err.field] = err.message;
+          }
+        } else if (error.response?.data?.message) {
+          this.errors.general = error.response.data.message;
+        } else {
+          this.errors.general = "Erreur inconnue.";
+        }
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+
+.modal-content {
+  width: 100%;
+  max-width: 500px;
+  background-color: var(--color-beige);
+  border: 2px solid var(--color-brown);
+}
+
+.next {
+  background-color: var(--color-brown);
+  color: var(--color-white);
+  border: none;
+}
+
+</style>

--- a/pangeas-v1/src/components/Modal/DeleteUserDataModal.vue
+++ b/pangeas-v1/src/components/Modal/DeleteUserDataModal.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="modal-overlay">
+    <div class="modal-content p-4 rounded shadow">
+      <h3 class="mb-3 text-center">Confirmation de suppression des données</h3>
+
+      <div v-if="successMessage" class="alert alert-success text-center">
+        {{ successMessage }}
+      </div>
+
+      <form v-else @submit.prevent="submitDeletion">
+        <p class="text-center fw-bold text-danger mb-4">
+          Voulez-vous vraiment supprimer vos données personnelles ? <br />
+          Cette action est <u>irréversible</u> !
+        </p>
+
+        <div class="mb-3">
+          <label class="form-label">Adresse mail</label>
+          <input type="email" class="form-control" v-model="email" />
+          <small class="text-danger" v-if="errors.email">{{ errors.email }}</small>
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">Mot de passe</label>
+          <input type="password" class="form-control" v-model="password" />
+          <small class="text-danger" v-if="errors.password">{{ errors.password }}</small>
+        </div>
+
+        <div class="d-flex justify-content-between mt-4">
+          <button type="button" style="background-color: var(--color-brown);" class="btn text-white" @click="$emit('close')">Annuler</button>
+          <button type="submit" class="btn btn-danger text-white">Supprimer</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import axios from 'axios';
+
+export default {
+  data() {
+    return {
+      email: '',
+      password: '',
+      errors: {},
+      successMessage: ''
+    };
+  },
+  computed: {
+    ...mapState({ user: state => state.user })
+  },
+  mounted() {
+    if (this.user?.email) this.email = this.user.email;
+  },
+  methods: {
+    async submitDeletion() {
+      this.errors = {};
+      try {
+        const response = await axios.delete('/api/settings/data', {
+          data: {
+            email: this.email,
+            password: this.password
+          },
+          withCredentials: true
+        });
+
+        if (response.data.success) {
+          this.successMessage = response.data.message;
+
+          // (Optionnel) : reset du store si tu gères les stats/favoris côté front
+          this.$store.commit('setFavorites', []);
+          this.$store.commit('clearCurrentVisit');
+          this.$store.commit('setUserPosition', null);
+
+          setTimeout(() => {
+            this.$emit('close');
+          }, 2000);
+        }
+      } catch (error) {
+        if (error.response?.data?.errors) {
+          for (const err of error.response.data.errors) {
+            this.errors[err.field] = err.message;
+          }
+        } else if (error.response?.data?.message) {
+          this.errors.general = error.response.data.message;
+        } else {
+          this.errors.general = "Erreur inconnue.";
+        }
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+
+.modal-content {
+  width: 100%;
+  max-width: 500px;
+  background-color: var(--color-beige);
+  border: 2px solid var(--color-brown);
+}
+</style>

--- a/pangeas-v1/src/components/Modal/EmailUpdateModal.vue
+++ b/pangeas-v1/src/components/Modal/EmailUpdateModal.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="modal-overlay">
+    <div class="modal-content p-4 rounded shadow">
+      <h3 class="mb-3 text-center title">Modifier votre adresse mail</h3>
+
+      <div v-if="successMessage" class="alert alert-success text-center">
+        {{ successMessage }}
+      </div>
+
+      <form v-else @submit.prevent="submitForm">
+        <div class="mb-3">
+          <label class="form-label">Email actuel</label>
+          <input type="email" class="form-control" :value="user?.email" disabled />
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">Nouvel email</label>
+          <input type="email" class="form-control" v-model="newEmail" />
+          <small class="text-danger" v-if="errors.newEmail">{{ errors.newEmail }}</small>
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">Mot de passe</label>
+          <input type="password" class="form-control" v-model="password" />
+          <small class="text-danger" v-if="errors.password">{{ errors.password }}</small>
+        </div>
+
+        <div class="d-flex justify-content-between mt-4">
+          <button type="button" class="btn btn-danger text-white" @click="$emit('close')">Annuler</button>
+          <button type="submit" class="btn-validate">Valider</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+
+<script>
+import { mapState } from 'vuex';
+import axios from 'axios';
+
+export default {
+  data() {
+    return {
+      newEmail: '',
+      password: '',
+      errors: {},
+      successMessage: ''
+    };
+  },
+  computed: {
+    ...mapState({
+      user: state => state.user
+    })
+  },
+  methods: {
+    async submitForm() {
+      this.errors = {};
+      try {
+        const response = await axios.put('api/settings/email', {
+          newEmail: this.newEmail,
+          password: this.password
+        });
+
+        if (response.data.success) {
+          this.successMessage = response.data.message;
+          this.$store.commit('setUser', {
+            ...this.user,
+            email: response.data.email
+          });
+          setTimeout(() => {
+            this.$emit('close');
+          }, 2000);
+        }
+      } catch (error) {
+        if (error.response?.data?.errors) {
+          for (const err of error.response.data.errors) {
+            this.errors[err.field] = err.message;
+          }
+        } else {
+          this.errors.general = "Une erreur est survenue.";
+        }
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+
+.modal-content {
+  width: 100%;
+  max-width: 500px;
+  background-color: var(--color-beige);
+  border: 3px solid var(--color-brown);
+}
+
+.title {
+  color: var(--color-brown);
+  font-weight: bold;
+  padding-bottom: 2rem;
+}
+
+label {
+  font-weight: bold;
+}
+
+.btn-validate {
+  background-color: var(--color-brown);
+  color: var(--color-white);
+  border: none;
+  padding: 0.5rem 1.2rem;
+  border-radius: 4px;
+  font-weight: bold;
+  transition: transform 0.2s ease;
+}
+
+.btn-validate:hover {
+  transform: scale(1.05);
+}
+
+</style>
+

--- a/pangeas-v1/src/components/Modal/PasswordUpdateModal.vue
+++ b/pangeas-v1/src/components/Modal/PasswordUpdateModal.vue
@@ -1,0 +1,146 @@
+<template>
+  <div class="modal-overlay">
+    <div class="modal-content p-4 rounded shadow">
+      <h3 class="mb-3 text-center">Modifier votre mot de passe</h3>
+
+      <div v-if="successMessage" class="alert alert-success text-center">
+        {{ successMessage }}
+      </div>
+
+      <form v-else @submit.prevent="handleSubmit">
+        <div class="mb-3">
+          <label class="form-label">Adresse mail</label>
+          <input type="email" class="form-control" v-model="email" />
+          <small class="text-danger" v-if="errors.email">{{ errors.email }}</small>
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">Mot de passe actuel</label>
+          <input type="password" class="form-control" v-model="currentPassword" />
+          <small class="text-danger" v-if="errors.currentPassword">{{ errors.currentPassword }}</small>
+        </div>
+
+        <div v-if="verified">
+          <div class="mb-3">
+            <label class="form-label">Nouveau mot de passe</label>
+            <input type="password" class="form-control" v-model="newPassword" />
+            <small class="text-danger" v-if="errors.newPassword">{{ errors.newPassword }}</small>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label">Confirmation du mot de passe</label>
+            <input type="password" class="form-control" v-model="confirmPassword" />
+            <small class="text-danger" v-if="errors.confirmPassword">{{ errors.confirmPassword }}</small>
+          </div>
+        </div>
+
+        <div class="d-flex justify-content-between mt-4">
+          <button type="button" class="btn btn-danger text-white" @click="$emit('close')">Annuler</button>
+          <button type="submit" class="btn text-white" :class="verified ? 'btn-brown' : 'btn-primary'">
+            {{ verified ? 'Valider' : 'Suivant' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import axios from 'axios';
+
+export default {
+  data() {
+    return {
+      email: '',
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+      verified: false,
+      successMessage: '',
+      errors: {}
+    };
+  },
+  computed: {
+    ...mapState({
+      user: state => state.user
+    })
+  },
+  mounted() {
+    this.email = this.user?.email || '';
+  },
+  methods: {
+    async handleSubmit() {
+      this.errors = {};
+
+      if (!this.verified) {
+        try {
+          await axios.post('/api/settings/verify-password', {
+            email: this.email,
+            password: this.currentPassword
+          });
+          this.verified = true;
+        } catch (error) {
+          if (error.response?.data?.errors) {
+            error.response.data.errors.forEach(err => {
+              this.errors[err.field] = err.message;
+            });
+          } else {
+            this.errors.general = 'Erreur inconnue.';
+          }
+        }
+      } else {
+        try {
+          const response = await axios.put('/api/settings/password', {
+            currentPassword: this.currentPassword,
+            newPassword: this.newPassword,
+            confirmPassword: this.confirmPassword
+          });
+
+          if (response.data.success) {
+            this.successMessage = response.data.message;
+            setTimeout(() => {
+              this.$emit('close');
+            }, 2000);
+          }
+        } catch (error) {
+          if (error.response?.data?.errors) {
+            error.response.data.errors.forEach(err => {
+              this.errors[err.field] = err.message;
+            });
+          } else {
+            this.errors.general = 'Erreur serveur.';
+          }
+        }
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+
+.modal-content {
+  width: 100%;
+  max-width: 500px;
+  background-color: var(--color-beige);
+  border: 2px solid var(--color-brown);
+}
+
+.btn-brown {
+  background-color: var(--color-brown);
+  border-color: var(--color-brown);
+}
+</style>

--- a/pangeas-v1/src/components/Modal/Registration.vue
+++ b/pangeas-v1/src/components/Modal/Registration.vue
@@ -83,7 +83,7 @@
         <input type="checkbox" id="terms" v-model="form.cgu_accepted" required />
         <label for="terms">
           Je déclare avoir lu et accepter les
-          <a href="#">Conditions Générales d’Utilisation</a>.
+          <router-link to="/cgu" @click.native="closeModal">Conditions Générales d’Utilisation</router-link>
           <p class="text-error" v-if="errors.cgu_accepted">{{ errors.cgu_accepted }}</p>
         </label>
       </div>
@@ -125,6 +125,9 @@ export default {
     };
   },
   methods: {
+    closeModal() {
+      this.$emit('close');
+    },
     handleAvatar(event) {
       const file = event.target.files[0];
       if (file) {

--- a/pangeas-v1/src/components/Sidebar.vue
+++ b/pangeas-v1/src/components/Sidebar.vue
@@ -27,7 +27,7 @@
             <img src="/icons/user.svg" alt="Compte" />
             Mon compte
           </li>
-          <li>
+          <li :class="{ active: isActiveRoute('Parametres') }" @click="goToSettings">
             <img src="/icons/cog.svg" alt="Paramètres" />
             Paramètres
           </li>
@@ -91,6 +91,10 @@ export default {
     goToHome() {
       this.isOpen = false;
       this.$router.push({ name: 'Home' });
+    },
+    goToSettings() {
+      this.isOpen = false;
+      this.$router.push({name : 'Parametres'})
     },
     isActiveRoute(name) {
       return this.$route.name === name;

--- a/pangeas-v1/src/components/account/EditAccount.vue
+++ b/pangeas-v1/src/components/account/EditAccount.vue
@@ -16,9 +16,9 @@
 
       <div class="col-12 col-md-8">
         <div class="pseudo-section">
-          <input v-if="isEditingPseudo" v-model="form.pseudo" class="pseudo-input" @blur="isEditingPseudo = false" @input="markModified" autofocus/>
-          <span v-else>{{ form.pseudo }}</span>
-          <img src="/icons/pen.svg" class="pen-icon cursor-pointer" @click="isEditingPseudo = true" />
+          <input v-if="isEditingPseudo" v-model="form.pseudo" class="pseudo-input"  @blur="isEditingPseudo = false" @input="markModified" autofocus/>
+          <span @click="isEditingPseudo = true" v-else>{{ form.pseudo }}</span>
+          <img src="/icons/pen.svg" class="pen-icon cursor-pointer"/>
         </div>
 
         <div class="bio-section">
@@ -219,6 +219,12 @@ export default {
   font-size: 1.8rem;
   font-weight: 700;
   margin-top: 1rem;
+  transition: transform 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+}
+
+.pseudo-section:hover {
+  transform: scale(1.05);
 }
 
 .pseudo-input {
@@ -229,6 +235,7 @@ export default {
   border: 2px solid var(--color-brown);
   outline: none;
 }
+
 
 /* Bio */
 .bio-section {

--- a/pangeas-v1/src/components/legal/CGU.vue
+++ b/pangeas-v1/src/components/legal/CGU.vue
@@ -1,0 +1,167 @@
+<template>
+  <div class="cgu-container">
+    <h1 class="text-center">Conditions Générales d’Utilisation</h1>
+    <p class="date-update text-center pb-4"><strong>Dernière mise à jour : 21 août 2025</strong></p>
+
+    <section>
+      <h2>1. Présentation de PANGEAS</h2>
+      <p>
+        <strong>PANGEAS</strong> est une application personnelle développée pour permettre aux utilisateurs, en particulier les jeunes adultes,
+        de <strong>découvrir des lieux d’intérêt</strong> en France, d’en apprendre davantage sur eux et d’effectuer un suivi de leurs visites.
+        L’application est actuellement <strong>gratuite</strong>, sans publicités ni achats intégrés.
+      </p>
+    </section>
+
+    <section>
+      <h2>2. Acceptation des CGU</h2>
+      <p>
+        En créant un compte ou en accédant aux services proposés par PANGEAS, l’utilisateur reconnaît avoir lu, compris et accepté les présentes Conditions Générales d’Utilisation.
+      </p>
+    </section>
+
+    <section>
+      <h2>3. Accès aux services</h2>
+      <p>
+        L’utilisateur peut consulter les lieux disponibles sans être connecté. Cependant, pour accéder à l’ensemble des fonctionnalités
+        (visites, statistiques, favoris, paramètres...), <strong>la création d’un compte et l’activation de la géolocalisation</strong> sont obligatoires.
+      </p>
+    </section>
+
+    <section>
+      <h2>4. Utilisation responsable</h2>
+      <p>
+        L’utilisateur s’engage à :
+        <ul>
+          <li>Respecter les lieux visités, leur environnement naturel, les animaux et les personnes qui les entretiennent</li>
+          <li>Ne pas utiliser l’application à des fins illégales, frauduleuses ou abusives</li>
+          <li>Ne pas perturber le bon fonctionnement de la plateforme (spam, surcharges, fausses visites, etc.)</li>
+        </ul>
+      </p>
+    </section>
+
+    <section>
+      <h2>5. Données personnelles</h2>
+      <p>
+        PANGEAS collecte les données suivantes : <strong>email, pseudo, avatar, bio, mot de passe hashé</strong>, préférences, favoris, statistiques,
+        historique de visites, état des visites, données de modification/inscription. Aucune <strong>position GPS</strong> n’est stockée en base de données,
+        elle est uniquement utilisée temporairement lors d’une visite.
+      </p>
+      <p>
+        L’utilisateur peut <strong>exporter ses données</strong> au format JSON, <strong>supprimer tout ou partie</strong> de ses données, ou bien
+        supprimer complètement son compte, ce qui effacera toutes les informations en base.
+      </p>
+    </section>
+
+    <section>
+      <h2>6. Sécurité</h2>
+      <p>
+        Les sessions sont sécurisées, les mots de passe sont <strong>cryptés et hashés</strong>. Un système de vérification est en place
+        pour accéder aux zones sensibles de l’application. En cas de problème technique, vous pouvez contacter :
+        <strong><a href="mailto:pangeas@contact.fr">pangeas@contact.fr</a></strong>.
+      </p>
+    </section>
+
+    <section>
+      <h2>7. Propriété intellectuelle</h2>
+      <p>
+        Le code source est protégé via un dépôt GitHub privé. Toute tentative de <strong>plagiat, hacking, détournement</strong> ou reproduction non autorisée du projet
+        pourra faire l’objet de poursuites. Le nom <strong>PANGEAS</strong>, son concept, son logo, ainsi que l’architecture de l’application sont protégés.
+      </p>
+      <p>
+        L’utilisateur est autorisé à partager ses contenus (statistiques, lieux visités, etc.) dans un cadre personnel et non commercial.
+      </p>
+    </section>
+
+    <section>
+      <h2>8. Limitations de responsabilité</h2>
+      <p>
+        Le développeur de PANGEAS ne peut être tenu responsable :
+        <ul>
+          <li>Des dommages ou comportements engendrés par des tiers lors d’une visite</li>
+          <li>Des erreurs de données ou de localisation</li>
+          <li>Des interruptions de service</li>
+        </ul>
+        En cas de bug ou d’anomalie, veuillez écrire à : <strong>pangeas@contact.fr</strong>.
+      </p>
+    </section>
+
+    <section>
+      <h2>9. Sanctions en cas de non-respect</h2>
+      <p>
+        En cas de violation des présentes CGU ou de comportement inapproprié, le développeur de PANGEAS se réserve le droit de
+        <strong>suspendre ou supprimer un compte utilisateur</strong>, sans préavis.
+      </p>
+    </section>
+
+    <section>
+      <h2>10. Modifications des CGU</h2>
+      <p>
+        Les présentes CGU peuvent être modifiées à tout moment. En cas de modification majeure, la date sera mise à jour et les utilisateurs pourront en être informés.
+        Il est recommandé de les consulter régulièrement.
+      </p>
+    </section>
+
+    <section>
+      <h2>11. Droit applicable et litiges</h2>
+      <p>
+        Les présentes CGU sont soumises au droit français. En cas de litige, et à défaut de solution amiable, l’affaire pourra être portée devant le tribunal compétent.
+      </p>
+    </section>
+
+    <section>
+      <h2>12. Contact</h2>
+      <p>
+        Pour toute question ou signalement, vous pouvez écrire à : <strong><a href="mailto:pangeas@contact.fr">pangeas@contact.fr</a></strong>
+      </p>
+    </section>
+    <button class="btn back-button" @click="goBack">Retour</button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Cgu',
+  methods: {
+    goBack() {
+      this.$router.go(-1)
+    }
+  }
+}
+</script>
+
+<style scoped>
+.cgu-container {
+  background-color: var(--color-beige);
+  color: var(--color-brown);
+  padding: 2rem;
+  line-height: 1.7;
+}
+
+h1, h2, h3 {
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.back-button {
+  margin: 2rem 0;
+  color: var(--color-beige);
+  font-size: 1rem;
+  cursor: pointer;
+  font-weight: bold;
+  background-color: var(--color-brown);
+  border: 3px solid transparent;
+  border-radius: 5px;
+  transition: all 0.2s ease;
+}
+
+.back-button:hover {
+  background-color: var(--color-beige);
+  color: var(--color-brown);
+  border: 3px solid var(--color-brown);
+}
+
+a {
+  color: var(--color-brown);
+  text-decoration: underline;
+}
+</style>

--- a/pangeas-v1/src/components/legal/MentionsLegales.vue
+++ b/pangeas-v1/src/components/legal/MentionsLegales.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="legal-container">
+    <h1 class="text-center">Mentions Légales</h1>
+    <p class="date-update text-center pb-4"><strong>Dernière mise à jour : 21 août 2025</strong></p>
+
+    <section>
+      <h2>1. Éditeur du site</h2>
+      <p>
+        Le site <strong>PANGEAS</strong> est développé dans le cadre d’un projet personnel à visée pédagogique,
+        sous la responsabilité de <strong>SANCHEZ Sacha</strong>, dans le cadre de l’école <strong>Need For School</strong>.
+        <br />
+        Adresse de l’établissement : <strong>10 rue Général Sarrail, 76000 Rouen</strong><br />
+        Adresse email de contact : <strong><a href="mailto:pangeas@contact.fr">pangeas@contact.fr</a></strong>
+      </p>
+    </section>
+
+    <section>
+      <h2>2. Hébergement</h2>
+      <p>
+        Le site est hébergé sur les serveurs de l’école <strong>Need For School</strong>, via une infrastructure Apache.
+        <br />
+        Adresse de l’hébergeur : <strong>10 rue Général Sarrail, 76000 Rouen</strong>
+      </p>
+    </section>
+
+    <section>
+      <h2>3. Propriété intellectuelle</h2>
+      <p>
+        L’ensemble du contenu du site <strong>PANGEAS</strong> (code, logo, structure, textes, styles) est protégé au titre du droit de la propriété intellectuelle.
+        Toute reproduction, représentation, modification, publication, adaptation, même partielle, sans autorisation écrite préalable est strictement interdite.
+        <br />
+        Le code source est hébergé de manière sécurisée sur un dépôt GitHub privé. L’identité visuelle, bien que non déposée, est considérée comme appartenant exclusivement à l’auteur.
+      </p>
+    </section>
+
+    <section>
+      <h2>4. Conditions d’utilisation</h2>
+      <p>
+        L’utilisateur s’engage à utiliser le site dans le respect des <router-link to="/cgu">Conditions Générales d’Utilisation</router-link>.
+        Toute activité illicite, abusive ou irrespectueuse du fonctionnement du site ou des autres utilisateurs pourra entraîner des sanctions, y compris la suppression de compte.
+        <br />
+        L’accès à certaines fonctionnalités du site nécessite la création d’un compte ainsi que l’activation de la géolocalisation. Le site est gratuit, sans publicité ni achat intégré.
+      </p>
+    </section>
+
+    <section>
+      <h2>5. Responsabilité</h2>
+      <p>
+        L’auteur de PANGEAS ne saurait être tenu responsable d’un mauvais usage du site, d’erreurs techniques, de contenus extérieurs ou de dommages indirects causés à l’utilisateur.
+        <br />
+        En cas de bug ou de problème technique, un contact est possible via l’adresse suivante :
+        <strong><a href="mailto:pangeas@contact.fr">pangeas@contact.fr</a></strong>.
+      </p>
+    </section>
+
+    <section>
+      <h2>6. Droit applicable</h2>
+      <p>
+        Les présentes mentions légales sont régies par le droit français. En cas de litige, les parties s’efforceront de trouver une solution amiable.
+        À défaut, le litige pourra être porté devant le tribunal compétent.
+      </p>
+    </section>
+    <button class="btn back-button" @click="goBack">Retour</button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "MentionsLegales",
+  methods: {
+    goBack() {
+      this.$router.go(-1);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.legal-container {
+  background-color: var(--color-beige);
+  color: var(--color-brown);
+  padding: 2rem;
+  line-height: 1.7;
+}
+
+h1, h2 {
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+a {
+  color: var(--color-brown);
+  text-decoration: underline;
+}
+
+.back-button {
+  margin: 2rem 0;
+  color: var(--color-beige);
+  font-size: 1rem;
+  cursor: pointer;
+  font-weight: bold;
+  background-color: var(--color-brown);
+  border: 3px solid transparent;
+  transition: all 0.2s ease;
+}
+
+.back-button:hover {
+  background-color: var(--color-beige);
+  color: var(--color-brown);
+  border: 3px solid var(--color-brown);
+}
+</style>

--- a/pangeas-v1/src/components/legal/PolConf.vue
+++ b/pangeas-v1/src/components/legal/PolConf.vue
@@ -1,0 +1,167 @@
+<template>
+  <div class="legal-container">
+    <h1 class="text-center pb-4">Politique de Confidentialité</h1>
+
+    <section>
+      <h2>1. Responsable du traitement</h2>
+      <p>
+        Le traitement des données personnelles est réalisé par <strong>SANCHEZ Sacha</strong>, dans le cadre d’un projet d’étude développé au sein de l’école <strong>Need For School</strong>.
+        <br />
+        Pour toute question ou demande : <strong><a href="mailto:pangeas@contact.fr">pangeas@contact.fr</a></strong>.
+      </p>
+    </section>
+
+    <section>
+      <h2>2. Base légale du traitement</h2>
+      <p>
+        Les données personnelles sont traitées sur la base :
+        <ul>
+          <li><strong>du consentement explicite</strong> de l’utilisateur lors de la création de compte,</li>
+          <li><strong>d’un intérêt légitime</strong> (suivi statistique, amélioration de l’expérience utilisateur),</li>
+          <li><strong>d’une obligation légale</strong> (transparence sur les données collectées).</li>
+        </ul>
+        La transparence étant une valeur centrale du projet <strong>PANGEAS</strong>, le respect du consentement de l’utilisateur est prioritaire à tout moment.
+      </p>
+    </section>
+
+    <section>
+      <h2>3. Finalités de la collecte</h2>
+      <p>
+        Les données sont collectées pour permettre :
+        <ul>
+          <li>La création et gestion du compte utilisateur (email, pseudo, mot de passe hashé, bio, avatar),</li>
+          <li>Le suivi des visites, favoris, paramètres et statistiques personnelles,</li>
+          <li>Le calcul temporaire du tracé GPS pour valider les visites, sans conservation de la position,</li>
+          <li>L’export, la modification ou la suppression des données à la demande de l’utilisateur.</li>
+        </ul>
+        <br />
+        <strong>Philosophie du projet :</strong>
+        <br />
+        Le projet <strong>PANGEAS</strong> poursuit une ambition centrale : démontrer que la technologie n’est pas nécessairement un frein à la reconnexion au réel, mais qu’elle peut au contraire devenir un moteur d’éveil, de mouvement et de curiosité.
+        Inspirée par des modèles comme Pokémon Go, l'application propose de détourner l’usage passif du smartphone pour stimuler l’exploration, l’activité physique et la découverte culturelle.
+        <br /><br />
+        L’application se veut un pont entre deux univers : l’environnement numérique, et l’environnement naturel. À travers une carte stylisée, des lieux immersifs et des défis à relever dans le monde réel, <strong>PANGEAS</strong> redonne du sens à l’usage des outils numériques.
+        <br /><br />
+        Le projet vise aussi à encourager un mode de vie plus actif et plus sain, en valorisant la marche et la découverte de son territoire grâce à une gamification bienveillante.
+      </p>
+    </section>
+
+    <section>
+      <h2>4. Destinataires des données</h2>
+      <p>
+        Les données collectées ne sont <strong>ni vendues</strong>, <strong>ni cédées</strong> à des tiers. Elles sont exclusivement utilisées dans le cadre du projet <strong>PANGEAS</strong>.
+      </p>
+    </section>
+
+    <section>
+      <h2>5. Durée de conservation</h2>
+      <p>
+        Les données sont conservées jusqu’à ce que l’utilisateur en demande la suppression via son espace personnel, ou supprime directement son compte. Une demande peut également être faite par mail à <strong><a href="mailto:pangeas@contact.fr">pangeas@contact.fr</a></strong>.
+      </p>
+    </section>
+
+    <section>
+      <h2>6. Droits des utilisateurs</h2>
+      <p>
+        Conformément au Règlement Général sur la Protection des Données (RGPD), chaque utilisateur dispose des droits suivants :
+        <ul>
+          <li><strong>Droit d’accès</strong> à ses données,</li>
+          <li><strong>Droit de rectification</strong> ou de suppression,</li>
+          <li><strong>Droit d’opposition</strong> ou de limitation du traitement,</li>
+          <li><strong>Droit à la portabilité</strong> via l’export au format JSON,</li>
+          <li><strong>Droit d’introduire une réclamation</strong> auprès de la CNIL.</li>
+        </ul>
+        PANGEAS est également attentif à l’<strong>inclusivité</strong> de son interface :
+        <ul>
+          <li>Contrastes et tailles de police accessibles,</li>
+          <li>Structure logique des balises (titres, alt, navigation clavier),</li>
+          <li>Utilisation possible à une main sur smartphone.</li>
+        </ul>
+      </p>
+    </section>
+
+    <section>
+      <h2>7. Cookies et traceurs</h2>
+      <p>
+        Le site <strong>PANGEAS</strong> n’utilise aucun cookie à des fins publicitaires ou de suivi. Seul un cookie de session sécurisé est utilisé pour maintenir la connexion (connect.sid).
+        Aucun autre traceur tiers n’est volontairement implémenté.
+      </p>
+    </section>
+
+    <section>
+      <h2>8. Sécurité des données</h2>
+      <p>
+        Les données sont protégées par :
+        <ul>
+          <li>Un système de <strong>sessions sécurisées</strong>,</li>
+          <li>Le <strong>hashage des mots de passe</strong>,</li>
+          <li>La <strong>non-conservation de la position GPS</strong> en base de données.</li>
+        </ul>
+        L’accès aux fonctionnalités sensibles est conditionné à une authentification valide.
+      </p>
+    </section>
+
+    <section>
+      <h2>9. Modifications</h2>
+      <p>
+        La présente politique peut être modifiée pour s’adapter à l’évolution du projet ou du cadre légal. La dernière mise à jour a été effectuée le <strong>21 août 2025</strong>.
+      </p>
+    </section>
+
+    <section>
+      <h2>10. Litiges et contact</h2>
+      <p>
+        En cas de litige, une solution amiable sera privilégiée. À défaut, le litige pourra être porté devant le tribunal compétent.
+        Pour toute demande, vous pouvez nous contacter à <strong><a href="mailto:pangeas@contact.fr">pangeas@contact.fr</a></strong>.
+      </p>
+    </section>
+    <button class="btn back-button" @click="goBack">Retour</button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "PolitiqueConfidentialite",
+  methods: {
+    goBack() {
+      this.$router.go(-1);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.legal-container {
+  background-color: var(--color-beige);
+  color: var(--color-brown);
+  padding: 2rem;
+  line-height: 1.7;
+}
+
+h1, h2 {
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+a {
+  color: var(--color-brown);
+  text-decoration: underline;
+}
+
+.back-button {
+  margin: 2rem 0;
+  color: var(--color-beige);
+  font-size: 1rem;
+  cursor: pointer;
+  font-weight: bold;
+  background-color: var(--color-brown);
+  border: 3px solid transparent;
+  transition: all 0.2s ease;
+}
+
+.back-button:hover {
+  background-color: var(--color-beige);
+  color: var(--color-brown);
+  border: 3px solid var(--color-brown);
+}
+</style>

--- a/pangeas-v1/src/components/settings/SettingsAccount.vue
+++ b/pangeas-v1/src/components/settings/SettingsAccount.vue
@@ -1,0 +1,62 @@
+<template>
+  <div style="background-color: var(--color-beige)">
+    <div class="settings-container">
+      <div class="d-flex align-items-center justify-content-center gap-2 mb-4">
+        <h1 class="mb-0">Paramètres</h1>
+        <img src="/icons/cog.svg" alt="Paramètres" width="32" height="32" />
+      </div>
+      <SettingsEditInfo @logout="handleLogout"/>
+      <SettingsAccountControl />
+      <SettingsLegalInfo />
+
+      <div class="app-version">
+        Version de l’application : <strong>V1.11.3</strong>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import SettingsEditInfo from './SettingsEditInfo.vue';
+import store from "@/store/index.js";
+import axios from "@/axios";
+import SettingsAccountControl from "@/components/settings/SettingsAccountControl.vue";
+import SettingsLegalInfo from "@/components/settings/SettingsLegalInfo.vue";
+
+export default {
+  components: {
+    SettingsLegalInfo,
+    SettingsAccountControl,
+    SettingsEditInfo
+  },
+  methods: {
+    async handleLogout() {
+      try {
+        await axios.post('api/auth/logout', {}, { withCredentials: true });
+        store.commit('logout');
+        this.$router.push({ name: 'Home' });
+      } catch (err) {
+        console.error('Erreur lors de la déconnexion :', err);
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.settings-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+.app-version {
+  text-align: center;
+  margin-top: 2rem;
+  font-size: 0.9rem;
+  color: var(--color-brown);
+  background-color: var(--color-beige);
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--color-brown);
+  font-style: italic;
+}
+</style>

--- a/pangeas-v1/src/components/settings/SettingsAccountControl.vue
+++ b/pangeas-v1/src/components/settings/SettingsAccountControl.vue
@@ -1,0 +1,161 @@
+<template>
+  <section class="settings-card shadow">
+    <h2 class="section-title">Gestion du compte</h2>
+
+    <div class="info-line">
+      <div class="info-text">
+        <strong>Suppression du compte</strong>
+      </div>
+      <span class="delete-link" @click="showDeleteModal = true">Supprimer</span>
+    </div>
+
+    <div class="info-line">
+      <div class="info-text">
+        <strong>Suppression des données</strong>
+      </div>
+      <span class="delete-link" @click="showDeleteDataModal = true">Supprimer</span>
+    </div>
+
+    <div class="info-line">
+      <div class="info-text">
+        <strong>Export des données (format JSON)</strong>
+      </div>
+      <span class="download-link" @click="downloadJson">Télécharger</span>
+    </div>
+
+    <DeleteAccountModal v-if="showDeleteModal" @close="showDeleteModal = false" />
+    <DeleteUserDataModal v-if="showDeleteDataModal" @close="showDeleteDataModal = false" />
+  </section>
+</template>
+
+
+<script>
+import { mapState } from 'vuex';
+import axios from 'axios';
+import DeleteAccountModal from '../modal/DeleteAccountModal.vue';
+import DeleteUserDataModal from '../modal/DeleteUserDataModal.vue';
+
+
+
+export default {
+  components: {
+    DeleteAccountModal,
+    DeleteUserDataModal
+  },
+  data() {
+    return {
+      showDeleteModal: false,
+      showDeleteDataModal: false,
+      geolocationEnabled: false
+    };
+  },
+  computed: {
+    ...mapState({
+      user: state => state.user
+    })
+  },
+  methods: {
+    async downloadJson() {
+      try {
+        const res = await axios.get('/api/settings/export', {
+          responseType: 'blob',
+          withCredentials: true
+        });
+        const url = window.URL.createObjectURL(new Blob([res.data]));
+        const link = document.createElement('a');
+        link.href = url;
+        link.setAttribute('download', 'mes_donnees_pangeas.json');
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+      } catch (err) {
+        console.error("Erreur export JSON :", err);
+        alert("Erreur lors de l'export.");
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.settings-card {
+  background-color: var(--color-beige);
+  border: 4px solid var(--color-brown);
+  color: var(--color-brown);
+  border-radius: 8px;
+  padding: 2rem;
+  margin: 4rem 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.section-title {
+  color: var(--color-brown);
+  font-size: 1.6rem;
+  margin-bottom: 2rem;
+}
+
+.info-line {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+  gap: 0.5rem;
+}
+
+.info-text {
+  flex: 1 1 70%;
+  display: flex;
+  flex-direction: column;
+  font-size: 1rem;
+}
+
+.download-link,
+.delete-link {
+  font-weight: bold;
+  cursor: pointer;
+  transition: transform 0.2s ease, color 0.2s ease;
+  white-space: nowrap;
+}
+
+.download-link {
+  color: var(--color-blue);
+}
+
+.delete-link {
+  color: #BB2D3B;
+}
+
+.download-link:hover,
+.delete-link:hover {
+  transform: scale(1.05);
+}
+
+/* Responsive pour mobile */
+@media (max-width: 600px) {
+  .settings-card {
+    padding: 1.5rem;
+  }
+
+  .info-line {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .delete-link,
+  .download-link {
+    align-self: flex-end;
+    margin-top: 0.5rem;
+  }
+
+  .info-text {
+    width: 100%;
+  }
+
+  .section-title {
+    font-size: 1.4rem;
+    text-align: center;
+  }
+}
+</style>
+

--- a/pangeas-v1/src/components/settings/SettingsEditInfo.vue
+++ b/pangeas-v1/src/components/settings/SettingsEditInfo.vue
@@ -1,0 +1,151 @@
+<template>
+  <section class="settings-card shadow">
+    <h2 class="section-title">Informations de profil</h2>
+
+    <div class="info-line">
+      <div class="info-text">
+        <strong>Pseudo :</strong>
+        <span>{{ user?.pseudo }}</span>
+      </div>
+      <router-link to="/mon-compte" class="edit-link" style="text-decoration: none">modifier</router-link>
+    </div>
+
+    <div class="info-line">
+      <div class="info-text">
+        <strong>Adresse mail :</strong>
+        <span>{{ user?.email }}</span>
+      </div>
+      <span class="edit-link" @click="openEmailModal">modifier</span>
+    </div>
+
+    <div class="info-line">
+      <div class="info-text">
+        <strong>Mot de passe :</strong>
+        <span>********</span>
+      </div>
+      <span class="edit-link" @click="openPasswordModal">modifier</span>
+    </div>
+
+    <div class="info-line">
+      <div class="info-text">
+        <strong>Se déconnecter</strong>
+      </div>
+      <span class="logout-link" @click="$emit('logout')">Déconnexion</span>
+    </div>
+
+    <EmailUpdateModal v-if="showEmailModal" @close="showEmailModal = false" />
+    <PasswordUpdateModal v-if="showPasswordModal" @close="showPasswordModal = false" />
+  </section>
+</template>
+
+
+<script>
+import { mapState } from 'vuex';
+import EmailUpdateModal from '../modal/EmailUpdateModal.vue';
+import PasswordUpdateModal from '../modal/PasswordUpdateModal.vue';
+
+export default {
+  components: {
+    EmailUpdateModal,
+    PasswordUpdateModal
+  },
+  data() {
+    return {
+      showEmailModal: false,
+      showPasswordModal: false
+    };
+  },
+  computed: {
+    ...mapState({
+      user: state => state.user
+    })
+  },
+  methods: {
+    openEmailModal() {
+      this.showEmailModal = true;
+    },
+    openPasswordModal() {
+      this.showPasswordModal = true;
+    }
+  }
+};
+</script>
+
+<style scoped>
+.settings-card {
+  background-color: var(--color-beige);
+  border: 4px solid var(--color-brown);
+  color: var(--color-brown);
+  border-radius: 8px;
+  padding: 2rem;
+  margin: 4rem 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.section-title {
+  color: var(--color-brown);
+  font-size: 1.6rem;
+  margin-bottom: 2rem;
+}
+
+.info-line {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+  gap: 0.5rem;
+}
+
+.info-text {
+  flex: 1 1 70%;
+  display: flex;
+  flex-direction: column;
+  font-size: 1rem;
+}
+
+.edit-link,
+.logout-link {
+  font-weight: bold;
+  cursor: pointer;
+  transition: transform 0.2s ease, color 0.2s ease;
+  color: #007bff;
+  white-space: nowrap;
+}
+
+.logout-link {
+  color: #BB2D3B;
+}
+
+.edit-link:hover,
+.logout-link:hover {
+  transform: scale(1.05);
+}
+
+@media (max-width: 600px) {
+  .settings-card {
+    padding: 1.5rem;
+  }
+
+  .info-line {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .edit-link,
+  .logout-link {
+    align-self: flex-end;
+    margin-top: 0.5rem;
+  }
+
+  .info-text {
+    width: 100%;
+  }
+
+  .section-title {
+    font-size: 1.4rem;
+    text-align: center;
+  }
+}
+</style>
+

--- a/pangeas-v1/src/components/settings/SettingsLegalInfo.vue
+++ b/pangeas-v1/src/components/settings/SettingsLegalInfo.vue
@@ -1,0 +1,114 @@
+<template>
+  <section class="settings-card shadow">
+    <h2 class="section-title">Informations légales & contact</h2>
+
+    <div class="info-line">
+      <div class="info-text">
+        <strong>Conditions Générales d’Utilisation</strong>
+      </div>
+      <router-link class="edit-link" to="/cgu">Voir</router-link>
+    </div>
+
+    <div class="info-line">
+      <div class="info-text">
+        <strong>Politique de confidentialité</strong>
+      </div>
+      <router-link class="edit-link" to="/confidentialite">Voir</router-link>
+    </div>
+
+    <div class="info-line">
+      <div class="info-text">
+        <strong>Mentions légales</strong>
+      </div>
+      <router-link class="edit-link" to="/mentions-legales">Voir</router-link>
+    </div>
+
+    <div class="info-line">
+      <div class="info-text">
+        <strong>Adresse de contact :</strong>
+      </div>
+      <a href="mailto:pangeas@contact.fr" class="edit-link">pangeas@contact.fr</a>
+    </div>
+  </section>
+</template>
+
+
+<script>
+export default {
+  name: "SettingsLegalInfo"
+};
+</script>
+
+<style scoped>
+.settings-card {
+  background-color: var(--color-beige);
+  border: 4px solid var(--color-brown);
+  color: var(--color-brown);
+  border-radius: 8px;
+  padding: 2rem;
+  margin: 4rem 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.section-title {
+  color: var(--color-brown);
+  font-size: 1.6rem;
+  margin-bottom: 2rem;
+}
+
+.info-line {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+  gap: 0.5rem;
+}
+
+.info-text {
+  flex: 1 1 70%;
+  display: flex;
+  flex-direction: column;
+  font-size: 1rem;
+}
+
+.edit-link {
+  color: var(--color-blue);
+  font-weight: bold;
+  transition: transform 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.edit-link:hover {
+  transform: scale(1.05);
+}
+
+/* Responsive mobile */
+@media (max-width: 600px) {
+  .settings-card {
+    padding: 1.5rem;
+  }
+
+  .info-line {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .info-text {
+    width: 100%;
+  }
+
+  .edit-link {
+    align-self: flex-end;
+    margin-top: 0.5rem;
+  }
+
+  .section-title {
+    font-size: 1.4rem;
+    text-align: center;
+  }
+}
+</style>
+

--- a/pangeas-v1/src/router/index.js
+++ b/pangeas-v1/src/router/index.js
@@ -1,6 +1,10 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import UserAccount from '../components/account/UserAccount.vue';
 import PlaceDetail from "../components/Map/PlaceDetail.vue";
+import SettingsAccount from '../components/settings/SettingsAccount.vue';
+import CGU from '../components/legal/CGU.vue';
+import Confidentialite from '../components/legal/PolConf.vue';
+import MentionsLegales from '../components/legal/MentionsLegales.vue';
 import HomeView from "../HomeView.vue";
 
 const routes = [
@@ -16,9 +20,30 @@ const routes = [
         meta: { requiresAuth: true }
     },
     {
+        path: '/parametres',
+        name: 'Parametres',
+        component: SettingsAccount,
+        meta: { requiresAuth: true }
+    },
+    {
         path: '/lieux/:id',
         name: 'PlaceDetail',
         component: PlaceDetail,
+    },
+    {
+        path: '/cgu',
+        name : 'CGU',
+        component: CGU
+    },
+    {
+        path: '/confidentialite',
+        name : 'confidentialite',
+        component: Confidentialite
+    },
+    {
+        path: '/mentions-legales',
+        name: 'mentions-legales',
+        component: MentionsLegales
     }
 ];
 


### PR DESCRIPTION
Ajout de la page SettingsAccount et des 3 fichiers enfants qui gèrent : 
- L'édition du mot de passe et de l'email (SettingsEditInfo)
- La suppression du compte, la suppression des données ainsi que l'export des données au format JSON (SettingsAccountControl)
- La consultation des CGU, Politique de Confidentialité et des MentionsLégales (SettingsLegalInfo)
- Création de 2 modales pour la confirmation des suppression
-Modification Mineure