### PR TITLE
V2.0.2: add forgot password and reset password routes, update login m…

### DIFF
--- a/pangeas-v1/src/App.vue
+++ b/pangeas-v1/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container-fluid p-0">
-    <Sidebar v-if="!$route.path.startsWith('/admin')" @open-register="showRegisterModal" @open-login="showLoginModal"/>
+    <Sidebar v-if="showSidebar" @open-register="showRegisterModal" @open-login="showLoginModal"/>
     <router-view :places="places" />
     <transition name="fade">
       <div class="modal-overlay" v-if="showRegistration">
@@ -48,6 +48,25 @@ export default {
       showRegistration: false,
       showLogin: false,
     };
+  },
+  computed: {
+    isAuthRoute() {
+      return ['ForgotPassword', 'ResetPassword'].includes(this.$route.name);
+    },
+    showSidebar() {
+      return !this.$route.path.startsWith('/admin') && !this.isAuthRoute;
+    }
+  },
+  watch: {
+    '$route.name': {
+      immediate: true,
+      handler() {
+        if (this.isAuthRoute) {
+          this.showLogin = false;
+          this.showRegistration = false;
+        }
+      }
+    }
   },
   methods: {
     showRegisterModal() {

--- a/pangeas-v1/src/axios.js
+++ b/pangeas-v1/src/axios.js
@@ -9,7 +9,11 @@ const instance = axios.create({
 instance.interceptors.response.use(
     response => response,
     error => {
-        if (error.response && error.response.status === 401) {
+        const requestUrl = error.config?.url || '';
+        const isSessionCheck = requestUrl.includes('/api/auth/me');
+        const isAuthRoute = ['ForgotPassword', 'ResetPassword'].includes(router.currentRoute.value.name);
+
+        if (error.response && error.response.status === 401 && !isSessionCheck && !isAuthRoute) {
             store.commit('logout');
             router.push({ name: 'Home' });
         }

--- a/pangeas-v1/src/components/auth/ForgotPassword.vue
+++ b/pangeas-v1/src/components/auth/ForgotPassword.vue
@@ -1,0 +1,128 @@
+<template>
+  <main class="auth-page">
+    <section class="auth-panel">
+      <h1 class="form-title">Mot de passe oublie</h1>
+      <p class="auth-text">
+        Indiquez l'adresse mail de votre compte. Si elle existe, un lien de reinitialisation vous sera envoyé.
+      </p>
+
+      <form class="form-container" @submit.prevent="submitForm" novalidate>
+        <div class="input-duo">
+          <div class="input-group">
+            <span class="input-group-text">
+              <img src="/icons/mail.svg" alt="Mail" style="width: 18px;" />
+            </span>
+            <input type="email" class="form-control" placeholder="Adresse mail *" v-model.trim="email" required/>
+          </div>
+          <p class="text-error" v-if="errors.email">{{ errors.email }}</p>
+          <p class="text-error" v-if="errors.general">{{ errors.general }}</p>
+          <p class="success-message" v-if="successMessage">{{ successMessage }}</p>
+        </div>
+
+        <button type="submit" class="submit-btn" :disabled="isSubmitting">
+          {{ isSubmitting ? 'Envoi en cours...' : 'Envoyer le lien' }}
+        </button>
+      </form>
+
+      <router-link class="auth-link" :to="{ name: 'Home' }">Retour a l'accueil</router-link>
+    </section>
+  </main>
+</template>
+
+<script>
+import axios from "@/axios.js";
+
+export default {
+  name: "ForgotPassword",
+  data() {
+    return {
+      email: "",
+      errors: {},
+      successMessage: "",
+      isSubmitting: false
+    };
+  },
+  methods: {
+    async submitForm() {
+      this.errors = {};
+      this.successMessage = "";
+
+      if (!this.email) {
+        this.errors = { email: "L'adresse mail est obligatoire." };
+        return;
+      }
+
+      this.isSubmitting = true;
+
+      try {
+        await axios.post(
+            "/api/auth/forgot-password",
+            { email: this.email },
+            { headers: { "Content-Type": "application/json" } }
+        );
+
+        this.email = "";
+        this.successMessage = "Si un compte existe avec cette adresse, un e-mail de reinitialisation a ete envoye.";
+      } catch (error) {
+        if (error.response?.data?.errors) {
+          this.errors = error.response.data.errors.reduce((acc, err) => {
+            acc[err.field] = err.message;
+            return acc;
+          }, {});
+        } else {
+          this.errors = {
+            general: "Impossible d'envoyer la demande pour le moment."
+          };
+        }
+      } finally {
+        this.isSubmitting = false;
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.auth-page {
+  min-height: calc(100vh - 2rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  background: var(--color-beige);
+}
+
+.auth-panel {
+  width: min(540px, 100%);
+  color: var(--color-brown);
+}
+
+.auth-text {
+  margin-bottom: 1.5rem;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.auth-link {
+  display: block;
+  margin-top: 1.25rem;
+  color: var(--color-blue);
+  font-weight: bold;
+  text-align: center;
+}
+
+.submit-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.success-message {
+  color: var(--color-green);
+  font-weight: bold;
+  line-height: 1.4;
+  margin: 0;
+  text-align: center;
+}
+</style>
+
+<style src="../../assets/css/form.css"></style>

--- a/pangeas-v1/src/components/auth/ResetPassword.vue
+++ b/pangeas-v1/src/components/auth/ResetPassword.vue
@@ -1,0 +1,184 @@
+<template>
+  <main class="auth-page">
+    <section class="auth-panel">
+      <h1 class="form-title">Nouveau mot de passe</h1>
+      <p class="auth-text">
+        Choisissez un nouveau mot de passe pour recuperer l'acces a votre compte.
+      </p>
+
+      <form class="form-container" @submit.prevent="submitForm" novalidate>
+        <div class="input-duo">
+          <div class="input-group">
+            <span class="input-group-text">
+              <img src="/icons/lock.svg" alt="Mot de passe" style="width: 18px;" />
+            </span>
+            <input
+                type="password"
+                class="form-control"
+                placeholder="Nouveau mot de passe *"
+                v-model="form.password"
+                required
+            />
+          </div>
+          <p class="text-error" v-if="errors.password">{{ errors.password }}</p>
+
+          <div class="input-group">
+            <span class="input-group-text">
+              <img src="/icons/lock-open.svg" alt="Confirmation" style="width: 18px;" />
+            </span>
+            <input
+                type="password"
+                class="form-control"
+                placeholder="Confirmer le mot de passe *"
+                v-model="form.confirmPassword"
+                required
+            />
+          </div>
+          <p class="text-error" v-if="errors.confirmPassword">{{ errors.confirmPassword }}</p>
+          <p class="text-error" v-if="errors.token">{{ errors.token }}</p>
+          <p class="text-error" v-if="errors.general">{{ errors.general }}</p>
+          <p class="success-message" v-if="successMessage">{{ successMessage }}</p>
+        </div>
+
+        <button type="submit" class="submit-btn" :disabled="isSubmitting || !token">
+          {{ isSubmitting ? 'Mise a jour...' : 'Modifier le mot de passe' }}
+        </button>
+      </form>
+
+      <router-link class="auth-link" :to="{ name: 'Home' }">Retour a l'accueil</router-link>
+    </section>
+  </main>
+</template>
+
+<script>
+import axios from "@/axios.js";
+
+export default {
+  name: "ResetPassword",
+  data() {
+    return {
+      form: {
+        password: "",
+        confirmPassword: ""
+      },
+      errors: {},
+      successMessage: "",
+      isSubmitting: false
+    };
+  },
+  computed: {
+    token() {
+      return this.$route.query.token || this.$route.params.token || "";
+    }
+  },
+  mounted() {
+    if (!this.token) {
+      this.errors = {
+        token: "Le lien de reinitialisation est invalide ou incomplet."
+      };
+    }
+  },
+  methods: {
+    async submitForm() {
+      this.errors = {};
+      this.successMessage = "";
+
+      if (!this.token) {
+        this.errors = {
+          token: "Le lien de reinitialisation est invalide ou incomplet."
+        };
+        return;
+      }
+
+      if (!this.form.password) {
+        this.errors = { password: "Le nouveau mot de passe est obligatoire." };
+        return;
+      }
+
+      if (this.form.password !== this.form.confirmPassword) {
+        this.errors = {
+          confirmPassword: "Les mots de passe ne correspondent pas."
+        };
+        return;
+      }
+
+      this.isSubmitting = true;
+
+      try {
+        await axios.post(
+            "/api/auth/reset-password",
+            {
+              token: this.token,
+              password: this.form.password,
+              confirmPassword: this.form.confirmPassword
+            },
+            { headers: { "Content-Type": "application/json" } }
+        );
+
+        this.successMessage = "Votre mot de passe a bien ete modifie.";
+        setTimeout(() => {
+          this.$router.push({ name: "Home" });
+        }, 1200);
+      } catch (error) {
+        if (error.response?.data?.errors) {
+          this.errors = error.response.data.errors.reduce((acc, err) => {
+            acc[err.field] = err.message;
+            return acc;
+          }, {});
+        } else {
+          this.errors = {
+            general: error.response?.data?.message || "Impossible de modifier le mot de passe."
+          };
+        }
+      } finally {
+        this.isSubmitting = false;
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.auth-page {
+  min-height: calc(100vh - 2rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  background: var(--color-beige);
+}
+
+.auth-panel {
+  width: min(540px, 100%);
+  color: var(--color-brown);
+}
+
+.auth-text {
+  margin-bottom: 1.5rem;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.auth-link {
+  display: block;
+  margin-top: 1.25rem;
+  color: var(--color-blue);
+  font-weight: bold;
+  text-align: center;
+}
+
+.submit-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.success-message {
+  color: var(--color-green);
+  font-weight: bold;
+  line-height: 1.4;
+  margin: 0;
+  text-align: center;
+}
+</style>
+
+<style src="../../assets/css/form.css"></style>

--- a/pangeas-v1/src/components/modal/Connexion.vue
+++ b/pangeas-v1/src/components/modal/Connexion.vue
@@ -26,6 +26,12 @@
         <a href="#" @click.prevent="$emit('open-register-from-login')">Inscrivez-vous ici</a>
       </p>
 
+      <p class="link-register">
+        <a href="#" @click.prevent="goToForgotPassword">Mot de passe oublie ?</a>
+      </p>
+
+      <p class="text-error" v-if="errors.general">{{ errors.general }}</p>
+
       <button type="submit" class="submit-btn">Connexion</button>
     </form>
   </div>
@@ -80,6 +86,10 @@ export default {
           this.errors = { general: "Une erreur s’est produite." };
         }
       }
+    },
+    goToForgotPassword() {
+      this.$emit('close-login');
+      this.$router.push({ name: 'ForgotPassword' });
     },
     handleSuccessClose() {
       this.showSuccess = false;

--- a/pangeas-v1/src/components/modal/EmailUpdateModal.vue
+++ b/pangeas-v1/src/components/modal/EmailUpdateModal.vue
@@ -37,7 +37,7 @@
 
 <script>
 import { mapState } from 'vuex';
-import axios from 'axios';
+import axios from "@/axios.js";
 
 export default {
   data() {
@@ -57,7 +57,7 @@ export default {
     async submitForm() {
       this.errors = {};
       try {
-        const response = await axios.put('api/settings/email', {
+        const response = await axios.put('/api/settings/email', {
           newEmail: this.newEmail,
           password: this.password
         });

--- a/pangeas-v1/src/components/modal/PasswordUpdateModal.vue
+++ b/pangeas-v1/src/components/modal/PasswordUpdateModal.vue
@@ -9,110 +9,79 @@
 
       <form v-else @submit.prevent="handleSubmit">
         <div class="mb-3">
-          <label class="form-label">Adresse mail</label>
-          <input type="email" class="form-control" v-model="email" />
-          <small class="text-danger" v-if="errors.email">{{ errors.email }}</small>
-        </div>
-
-        <div class="mb-3">
           <label class="form-label">Mot de passe actuel</label>
           <input type="password" class="form-control" v-model="currentPassword" />
           <small class="text-danger" v-if="errors.currentPassword">{{ errors.currentPassword }}</small>
         </div>
 
-        <div v-if="verified">
-          <div class="mb-3">
-            <label class="form-label">Nouveau mot de passe</label>
-            <input type="password" class="form-control" v-model="newPassword" />
-            <small class="text-danger" v-if="errors.newPassword">{{ errors.newPassword }}</small>
-          </div>
+        <div class="mb-3">
+          <label class="form-label">Nouveau mot de passe</label>
+          <input type="password" class="form-control" v-model="newPassword" />
+          <small class="text-danger" v-if="errors.newPassword">{{ errors.newPassword }}</small>
+        </div>
 
-          <div class="mb-3">
-            <label class="form-label">Confirmation du mot de passe</label>
-            <input type="password" class="form-control" v-model="confirmPassword" />
-            <small class="text-danger" v-if="errors.confirmPassword">{{ errors.confirmPassword }}</small>
-          </div>
+        <div class="mb-3">
+          <label class="form-label">Confirmation du mot de passe</label>
+          <input type="password" class="form-control" v-model="confirmPassword" />
+          <small class="text-danger" v-if="errors.confirmPassword">{{ errors.confirmPassword }}</small>
         </div>
 
         <div class="d-flex justify-content-between mt-4">
           <button type="button" class="btn btn-danger text-white" @click="$emit('close')">Annuler</button>
-          <button type="submit" class="btn text-white" :class="verified ? 'btn-brown' : 'btn-primary'">
-            {{ verified ? 'Valider' : 'Suivant' }}
-          </button>
+          <button type="submit" class="btn btn-brown text-white">Valider</button>
         </div>
+
+        <button type="button" class="forgot-password-link" @click="goToForgotPassword">
+          Mot de passe oublie ?
+        </button>
       </form>
     </div>
   </div>
 </template>
 
 <script>
-import { mapState } from 'vuex';
-import axios from 'axios';
+import axios from "@/axios.js";
 
 export default {
   data() {
     return {
-      email: '',
       currentPassword: '',
       newPassword: '',
       confirmPassword: '',
-      verified: false,
       successMessage: '',
       errors: {}
     };
-  },
-  computed: {
-    ...mapState({
-      user: state => state.user
-    })
-  },
-  mounted() {
-    this.email = this.user?.email || '';
   },
   methods: {
     async handleSubmit() {
       this.errors = {};
 
-      if (!this.verified) {
-        try {
-          await axios.post('/api/settings/verify-password', {
-            email: this.email,
-            password: this.currentPassword
-          });
-          this.verified = true;
-        } catch (error) {
-          if (error.response?.data?.errors) {
-            error.response.data.errors.forEach(err => {
-              this.errors[err.field] = err.message;
-            });
-          } else {
-            this.errors.general = 'Erreur inconnue.';
-          }
-        }
-      } else {
-        try {
-          const response = await axios.put('/api/settings/password', {
-            currentPassword: this.currentPassword,
-            newPassword: this.newPassword,
-            confirmPassword: this.confirmPassword
-          });
+      try {
+        const response = await axios.put('/api/settings/password', {
+          currentPassword: this.currentPassword,
+          newPassword: this.newPassword,
+          confirmPassword: this.confirmPassword
+        });
 
-          if (response.data.success) {
-            this.successMessage = response.data.message;
-            setTimeout(() => {
-              this.$emit('close');
-            }, 2000);
-          }
-        } catch (error) {
-          if (error.response?.data?.errors) {
-            error.response.data.errors.forEach(err => {
-              this.errors[err.field] = err.message;
-            });
-          } else {
-            this.errors.general = 'Erreur serveur.';
-          }
+        if (response.data.success) {
+          this.successMessage = response.data.message;
+          setTimeout(() => {
+            this.$emit('close');
+          }, 2000);
+        }
+      } catch (error) {
+        if (error.response?.data?.errors) {
+          error.response.data.errors.forEach(err => {
+            this.errors[err.field] = err.message;
+          });
+        } else {
+          this.errors.general = 'Erreur serveur.';
         }
       }
+    },
+    goToForgotPassword() {
+      this.$emit('close');
+      this.$router.push({ name: 'ForgotPassword' });
     }
   }
 };
@@ -142,5 +111,12 @@ export default {
 .btn-brown {
   background-color: var(--color-brown);
   border-color: var(--color-brown);
+}
+
+.forgot-password-link {
+  display: block;
+  margin: 1rem auto 0;
+  color: var(--color-blue);
+  font-weight: bold;
 }
 </style>

--- a/pangeas-v1/src/router/index.js
+++ b/pangeas-v1/src/router/index.js
@@ -7,6 +7,8 @@ import CGU from '../components/legal/CGU.vue';
 import Confidentialite from '../components/legal/PolConf.vue';
 import MentionsLegales from '../components/legal/MentionsLegales.vue';
 import HomeView from "../HomeView.vue";
+import ForgotPassword from "../components/auth/ForgotPassword.vue";
+import ResetPassword from "../components/auth/ResetPassword.vue";
 
 const routes = [
     {
@@ -47,6 +49,16 @@ const routes = [
         name: 'mentions-legales',
         component: MentionsLegales,
         meta: { requiresAuth: true }
+    },
+    {
+        path: '/mot-de-passe-oublie',
+        name: 'ForgotPassword',
+        component: ForgotPassword
+    },
+    {
+        path: '/reset-password/:token?',
+        name: 'ResetPassword',
+        component: ResetPassword
     },
 //////////////////////////////////////////////////// ADMIN ROUTES//////////////////////////////////////////////////////////////////////
     {
@@ -118,6 +130,13 @@ const router = createRouter({
 
 router.beforeEach((to, from, next) => {
     const user = store.state.user;
+
+    if (to.query.token && to.name !== 'ResetPassword') {
+        return next({
+            name: 'ResetPassword',
+            query: { token: to.query.token }
+        });
+    }
 
     if (to.meta.requiresAdmin) {
         if (!user || user.role !== 'admin') {


### PR DESCRIPTION
### Mot de Passe Oublié

- Ajout du parcours complet de réinitialisation de mot de passe côté front.
- Ajout d’un lien “Mot de passe oublié ?” dans la modale de connexion.
- Création de la page /mot-de-passe-oublie pour saisir son adresse e-mail et demander un lien de réinitialisation.
- Création de la page /reset-password pour saisir un nouveau mot de passe depuis le lien reçu par e-mail.
- Gestion du token depuis l’URL : /reset-password?token=... ou /reset-password/:token.
- Correction d’un problème de redirection : le front ne renvoie plus automatiquement vers la carte quand /api/auth/me retourne 401 sur les pages de reset.
- Masquage de la sidebar et fermeture des modales de connexion/inscription sur les pages de réinitialisation.
- Mise à jour du formulaire de reset pour envoyer token, password et confirmPassword, comme attendu par le back.

Ajustement des paramètres compte :simplification de la modale de modification du mot de passe ;
- ajout d’un lien vers le flux “mot de passe oublié” ;
- correction de l’appel Axios pour modifier l’adresse e-mail.